### PR TITLE
fix error when game end🐛

### DIFF
--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -65,13 +65,11 @@ class Server(object):
         pass
 
     def _process_state_and_get_action(self, state, gameover):
-        self.get_grid_from_state(state)
-
-        actions = self.get_action(state, gameover)
-
         if gameover:
             return None
         else:
+            self.get_grid_from_state(state)
+            actions = self.get_action(state, gameover)
             return self._filter_invalid_actions(actions, state)
 
 


### PR DESCRIPTION
When game ends, it still calls
```python
        def _process_state_and_get_action(self, state, gameover):
            self.get_grid_from_state(state)     # there

            actions = self.get_action(state, gameover)

            if gameover:
                return None
            else:
                return self._filter_invalid_actions(actions, state)
```
It will make errors because state doesn't have property "pgs".