### PR TITLE
Fix message size and game over detection method

### DIFF
--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -65,13 +65,11 @@ class Server(object):
         pass
 
     def _process_state_and_get_action(self, state, gameover):
-        self.get_grid_from_state(state)
-
-        actions = self.get_action(state, gameover)
-
         if gameover:
             return None
         else:
+            self.get_grid_from_state(state)
+            actions = self.get_action(state, gameover)
             return self._filter_invalid_actions(actions, state)
 
 

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -41,7 +41,7 @@ class Server(object):
         self._connection.send(('%s\n' % data_string).encode('utf-8'))
 
     def _wait_for_message(self):
-        environment_message = self._connection.recv(4096).decode('utf-8')
+        environment_message = self._connection.recv(8192).decode('utf-8')
         if environment_message[0] == u'\n':
             return ('ACK')
         self._logger.debug('Message: %s' % environment_message)

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -58,7 +58,7 @@ class Server(object):
 
     def get_action(self, state, gameover):
         '''
-        To be implemented by a syper class
+        To be implemented by a super class
         :param state:
         :return:
         '''

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -2,6 +2,7 @@ import logging
 import socket
 import sys
 import json
+from abc import abstractmethod
 
 PLAYER = 0
 
@@ -16,6 +17,7 @@ UP = 0
 RIGHT = 1
 DOWN = 2
 LEFT = 3
+
 
 class Server(object):
 
@@ -56,6 +58,7 @@ class Server(object):
         busy_units = self.get_busy_units(state)
         return [action for action in actions if action['unitID'] not in busy_units]
 
+    @abstractmethod
     def get_action(self, state, gameover):
         '''
         To be implemented by a super class


### PR DESCRIPTION
This PR makes the message size larger (from 4096 to 8192 bytes), as states with many entities were being truncated and sent in two messages, making it impossible to read a single message as a JSON file.

Also, the way python-microRTS detects a game over has been changed, since it detected the game was over before even sending the first action.

I believe the second point fixes #2 while the first point was an intermediate bug I found on the way. 