### PR TITLE
Fix message size and game over detection

### DIFF
--- a/examples/random_actions.py
+++ b/examples/random_actions.py
@@ -11,8 +11,8 @@ class AI(Server):
     Randomly selects actions for each unit
     """
 
-    def __init__(self):
-        super(AI, self).__init__()
+    def __init__(self, player_id):
+        super(AI, self).__init__(player_id)
 
     def get_unit_by_type(self, units, unit_type):
         return [unit for unit in units if unit['type'] == unit_type]
@@ -30,7 +30,7 @@ class AI(Server):
 
         ## I AM PLAYER 0
         actions = []
-        units = unit_by_player[0]
+        units = unit_by_player[self.player_id]
 
         # Gets all the units that are currently busy performing an action
         busy_units = self.get_busy_units(state)
@@ -90,5 +90,5 @@ class AI(Server):
 
 
 if __name__ == '__main__':
-    ai = AI()
+    ai = AI(0)
     ai.start()

--- a/examples/random_actions.py
+++ b/examples/random_actions.py
@@ -12,8 +12,8 @@ class AI(Server):
     def __init__(self):
         super(AI, self).__init__()
 
-    def get_unit_by_type(self, units, type):
-        return [unit for unit in units if unit['type'] == type]
+    def get_unit_by_type(self, units, unit_type):
+        return [unit for unit in units if unit['type'] == unit_type]
 
     def get_action(self, state, gameover):
 

--- a/examples/random_actions.py
+++ b/examples/random_actions.py
@@ -81,12 +81,12 @@ class AI(Server):
         # If we dont have enought resources to run some commands, we remove those commands
         if potential_resource_usage > self.get_resources_for_player(state):
             for action in actions:
-                if action['unitAction']['type'] == pyrts.PRODUCE:
-                    action['unitAction'] = {'type': pyrts.NONE}
+                if action['unitAction']['type'] == pyrts.Action.PRODUCE:
+                    action['unitAction'] = {'type': pyrts.Action.NONE}
 
         # For busy units we need to just send NONE action (-1)
         for unit_id in busy_units:
-            actions.append({'unitID': unit_id, 'unitAction': {'type': pyrts.NONE}})
+            actions.append({'unitID': unit_id, 'unitAction': {'type': pyrts.Action.NONE}})
 
         return actions
 

--- a/examples/random_actions.py
+++ b/examples/random_actions.py
@@ -1,8 +1,10 @@
+import json
+import random
+from collections import defaultdict
+
 import pyrts
 from pyrts import Server
-import json
-from collections import defaultdict
-import random
+
 
 class AI(Server):
     """

--- a/examples/random_actions.py
+++ b/examples/random_actions.py
@@ -92,8 +92,7 @@ class AI(Server):
 
         return actions
 
-ai = AI()
 
 if __name__ == '__main__':
-    print('server is running')
+    ai = AI()
     ai.start()

--- a/examples/random_actions.py
+++ b/examples/random_actions.py
@@ -18,10 +18,6 @@ class AI(Server):
         return [unit for unit in units if unit['type'] == unit_type]
 
     def get_action(self, state, gameover):
-
-        if gameover:
-            return []
-
         unit_type_table = self.get_unit_type_table()
 
         #self._logger.debug(json.dumps(unit_type_table, indent=1, separators=(',', ': ')))

--- a/examples/random_bot_movement.py
+++ b/examples/random_bot_movement.py
@@ -10,8 +10,8 @@ class AI(Server):
     Finds a single worker and moves it randomly
     """
 
-    def __init__(self):
-        super(AI, self).__init__()
+    def __init__(self, player_id):
+        super(AI, self).__init__(player_id)
 
     def get_action(self, state, gameover):
         unit_by_player = defaultdict(list)
@@ -26,7 +26,7 @@ class AI(Server):
         unit_id = None
         ## find a unit that we can move
         ## I AM PLAYER 1
-        for unit in unit_by_player[1]:
+        for unit in unit_by_player[self.player_id]:
             if unit['type'] == 'Worker':
                 unit_id = unit['ID']
 
@@ -41,5 +41,5 @@ class AI(Server):
 
 
 if __name__ == '__main__':
-    ai = AI()
+    ai = AI(0)
     ai.start()

--- a/examples/random_bot_movement.py
+++ b/examples/random_bot_movement.py
@@ -1,7 +1,9 @@
-from pyrts import Server
 import json
 from collections import defaultdict
-from random import randint
+from random import choice
+
+from pyrts import Server, Direction
+
 
 class AI(Server):
     """
@@ -30,7 +32,7 @@ class AI(Server):
         if not unit_id:
             return []
 
-        unit_action = {'type': 1, 'parameter': randint(1,4)}
+        unit_action = {'type': 1, 'parameter': choice(Direction.as_list())}
         test_action = {'unitID': unit_id, 'unitAction': unit_action}
 
         return [test_action]

--- a/examples/random_bot_movement.py
+++ b/examples/random_bot_movement.py
@@ -37,8 +37,7 @@ class AI(Server):
         return [test_action]
 
 
-ai = AI()
 
 if __name__ == '__main__':
-    print('server is running')
+    ai = AI()
     ai.start()

--- a/examples/random_bot_movement.py
+++ b/examples/random_bot_movement.py
@@ -22,13 +22,15 @@ class AI(Server):
 
         ## CREATE A TEST ACTION
 
+
+        unit_id = None
         ## find a unit that we can move
         ## I AM PLAYER 1
         for unit in unit_by_player[1]:
             if unit['type'] == 'Worker':
                 unit_id = unit['ID']
 
-        if not unit_id:
+        if unit_id is None:
             return []
 
         unit_action = {'type': 1, 'parameter': choice(Direction.as_list())}

--- a/examples/random_bot_movement.py
+++ b/examples/random_bot_movement.py
@@ -13,8 +13,7 @@ class AI(Server):
     def __init__(self):
         super(AI, self).__init__()
 
-    def get_action(self, state):
-
+    def get_action(self, state,gameover):
         unit_by_player = defaultdict(list)
         for unit in state['pgs']['units']:
             unit_by_player[unit['player']].append(unit)

--- a/examples/random_bot_movement.py
+++ b/examples/random_bot_movement.py
@@ -13,7 +13,7 @@ class AI(Server):
     def __init__(self):
         super(AI, self).__init__()
 
-    def get_action(self, state,gameover):
+    def get_action(self, state, gameover):
         unit_by_player = defaultdict(list)
         for unit in state['pgs']['units']:
             unit_by_player[unit['player']].append(unit)

--- a/pyrts/__init__.py
+++ b/pyrts/__init__.py
@@ -1,18 +1,1 @@
-from pyrts.server import Server
-
-
-from pyrts.server import PLAYER
-
-# Actions
-from pyrts.server import NONE
-from pyrts.server import MOVE
-from pyrts.server import HARVEST
-from pyrts.server import RETURN
-from pyrts.server import PRODUCE
-from pyrts.server import ATTACK
-
-# Directions
-from pyrts.server import UP
-from pyrts.server import RIGHT
-from pyrts.server import DOWN
-from pyrts.server import LEFT
+from .server import Server, PLAYER, Action, Direction

--- a/pyrts/__init__.py
+++ b/pyrts/__init__.py
@@ -1,1 +1,1 @@
-from .server import Server, PLAYER, Action, Direction
+from .server import Server, Action, Direction

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -1,10 +1,11 @@
+import json
 import logging
 import socket
 import sys
-import json
 from abc import abstractmethod
 
 PLAYER = 0
+
 
 class Action:
     NONE = 0

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -65,13 +65,11 @@ class Server(object):
         pass
 
     def _process_state_and_get_action(self, state, gameover):
-        self.get_grid_from_state(state)
-
-        actions = self.get_action(state, gameover)
-
         if gameover:
             return None
         else:
+            self.get_grid_from_state(state)
+            actions = self.get_action(state, gameover)
             return self._filter_invalid_actions(actions, state)
 
 

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -41,7 +41,7 @@ class Server(object):
         self._connection.send(('%s\n' % data_string).encode('utf-8'))
 
     def _wait_for_message(self):
-        environment_message = self._connection.recv(4096).decode('utf-8')
+        environment_message = self._connection.recv(8192).decode('utf-8')
         if environment_message[0] == u'\n':
             return ('ACK')
         self._logger.debug('Message: %s' % environment_message)

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -17,7 +17,7 @@ class Action:
 
     @staticmethod
     def as_list():
-        return [NONE, MOVE, HARVEST, RETURN, PRODUCE, ATTACK]
+        return [Action.NONE, Action.MOVE, Action.HARVEST, Action.RETURN, Action.PRODUCE, Action.ATTACK]
 
 
 class Direction:
@@ -28,7 +28,7 @@ class Direction:
 
     @staticmethod
     def as_list():
-        return [UP, RIGHT, DOWN, LEFT]
+        return [Direction.UP, Direction.RIGHT, Direction.DOWN, Direction.LEFT]
 
 
 class Server(object):

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -58,7 +58,7 @@ class Server(object):
 
     def get_action(self, state, gameover):
         '''
-        To be implemented by a syper class
+        To be implemented by a super class
         :param state:
         :return:
         '''

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -2,6 +2,7 @@ import logging
 import socket
 import sys
 import json
+from abc import abstractmethod
 
 PLAYER = 0
 
@@ -16,6 +17,7 @@ UP = 0
 RIGHT = 1
 DOWN = 2
 LEFT = 3
+
 
 class Server(object):
 
@@ -56,6 +58,7 @@ class Server(object):
         busy_units = self.get_busy_units(state)
         return [action for action in actions if action['unitID'] not in busy_units]
 
+    @abstractmethod
     def get_action(self, state, gameover):
         '''
         To be implemented by a super class

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -215,10 +215,7 @@ class Server(object):
             return unit['x'] - 1, unit['y']
 
     def _is_on_grid(self, position):
-        return position[0] >= 0 and \
-               position[1] >= 0 and \
-               position[0] < self._max_x and \
-               position[1] < self._max_y
+        return 0 <= position[0] < self._max_x and 0 <= position[1] < self._max_y
 
     def get_available_actions_by_type_name(self, unit_type_table, type_name):
         """
@@ -309,7 +306,7 @@ class Server(object):
         self._max_x = state['pgs']['width']
         self._max_y = state['pgs']['height']
 
-        return (self._max_x, self._max_y)
+        return self._max_x, self._max_y
 
     def get_resource_usage_from_state(self, state):
         """

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -31,11 +31,12 @@ class Direction:
 
 class Server(object):
 
-    def __init__(self):
+    def __init__(self, player_id):
         logging.basicConfig()
         self._logger = logging.getLogger('RTSServer')
         self._logger.setLevel(logging.DEBUG)
-
+        
+        self.player_id = player_id
         self._max_x = None
         self._max_y = None
 
@@ -144,23 +145,23 @@ class Server(object):
             ]
         )
 
-    def _get_valid_base_positions(self, state, player_id):
+    def _get_valid_base_positions(self, state):
         return set(
             [
                 (unit['x'], unit['y']) for unit in state['pgs']['units']
-                if unit['type'] == "Base" and unit['player'] == player_id
+                if unit['type'] == "Base" and unit['player'] == self.player_id
             ]
         )
 
-    def _get_valid_attack_positions(self, state, player_id):
+    def _get_valid_attack_positions(self, state):
         return set(
             [
                 (unit['x'], unit['y']) for unit in state['pgs']['units']
-                if unit['type'] != "Resource" and unit['player'] != player_id
+                if unit['type'] != "Resource" and unit['player'] != self.player_id
             ]
         )
 
-    def get_valid_action_positions_for_state(self, state, player_id):
+    def get_valid_action_positions_for_state(self, state):
         """
         Returns a tuple containing the following:
         invalid_move_positions - a set of all the positions that cannot be moved into
@@ -172,10 +173,9 @@ class Server(object):
         """
 
         return (
-            self._get_invalid_move_positions(state),
-            self._get_valid_harvest_positions(state),
-            self._get_valid_base_positions(state, player_id),
-            self._get_valid_attack_positions(state, player_id)
+            self._get_invalid_move_positions(state), self._get_valid_harvest_positions(state),
+            self._get_valid_base_positions(state),
+            self._get_valid_attack_positions(state)
         )
 
     def get_valid_actions_for_unit(self, unit, available_actions, valid_positions):

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -62,21 +62,22 @@ class Server(object):
         return message_parts
 
     def _filter_invalid_actions(self, actions, state):
-        '''
+        """
         Get the units that are currently performing actions from the state and remove any actions that refer to these
         units
         :return: A filtered list of all the actions that can be applied
-        '''
+        """
         busy_units = self.get_busy_units(state)
         return [action for action in actions if action['unitID'] not in busy_units]
 
     @abstractmethod
     def get_action(self, state, gameover):
-        '''
+        """
         To be implemented by a super class
         :param state:
+        :param gameover:
         :return:
-        '''
+        """
         pass
 
     def _process_state_and_get_action(self, state, gameover):
@@ -137,16 +138,15 @@ class Server(object):
 
 
     def get_valid_action_positions_for_state(self, state):
-        '''
+        """
         Returns a tuple containing the following:
         invalid_move_positions - a set of all the positions that cannot be moved into
         valid_harvest_positions -  a set of all the resource locations
         valid_base_positions - a set of the positions of bases on the current players team
         valid_attack_positions - a set of the positions that can be attacked
 
-        These positions can be cross-referenced with possible actions that units can perform, to make sure no invalid
-        actions are sent to the environment
-        '''
+        These positions can be cross-referenced with possible actions that units can perform, to make sure no invalid actions are sent to the environment
+        """
 
         return (
             self._get_invalid_move_positions(state),
@@ -156,13 +156,13 @@ class Server(object):
         )
 
     def get_valid_actions_for_unit(self, unit, available_actions, valid_positions):
-        '''
+        """
         Get the actions that are valid for a unit to perform.
 
         An action is INVALID if the action cannot be performed in the environment.
 
         For example, if the action is MOVE(left) but the position to the left of the unit is blocked
-        '''
+        """
 
         (
             invalid_move_positions,
@@ -221,9 +221,9 @@ class Server(object):
                position[1] < self._max_y
 
     def get_available_actions_by_type_name(self, unit_type_table, type_name):
-        '''
-        Gets a list of the available actions that can be performed by a particlar unit
-        '''
+        """
+        Given the unit type and the unit type table, return a complete list of the possible actions that unit can perform
+        """
 
         available_actions = []
 
@@ -287,9 +287,9 @@ class Server(object):
         return available_actions
 
     def get_resources_for_player(self, state, for_player=None):
-        '''
+        """
         Get the number of resources the player currently has available
-        '''
+        """
 
         if not for_player:
             for_player = 0
@@ -302,9 +302,9 @@ class Server(object):
         return [{'type': action_type, 'parameter': direction} for direction in Direction.as_list()]
 
     def get_grid_from_state(self, state):
-        '''
+        """
         Gets the width and height of the environment
-        '''
+        """
 
         self._max_x = state['pgs']['width']
         self._max_y = state['pgs']['height']
@@ -312,9 +312,9 @@ class Server(object):
         return (self._max_x, self._max_y)
 
     def get_resource_usage_from_state(self, state):
-        '''
+        """
         How many resources are currently being used to build units
-        '''
+        """
 
         used_resources = 0
         unit_types = self._unit_type_table['unitTypes']
@@ -328,9 +328,9 @@ class Server(object):
         return used_resources
 
     def get_resource_usage_from_actions(self, actions):
-        '''
+        """
         From a list of actions, sum the cost of the actions
-        '''
+        """
 
         used_resources = 0
         unit_types = self._unit_type_table['unitTypes']

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -4,8 +4,6 @@ import socket
 import sys
 from abc import abstractmethod
 
-PLAYER = 0
-
 
 class Action:
     NONE = 0
@@ -37,6 +35,9 @@ class Server(object):
         logging.basicConfig()
         self._logger = logging.getLogger('RTSServer')
         self._logger.setLevel(logging.DEBUG)
+
+        self._max_x = None
+        self._max_y = None
 
         self._s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -144,23 +145,23 @@ class Server(object):
             ]
         )
 
-    def _get_valid_base_positions(self, state):
+    def _get_valid_base_positions(self, state, player_id):
         return set(
             [
                 (unit['x'], unit['y']) for unit in state['pgs']['units']
-                if unit['type'] == "Base" and unit['player'] == PLAYER
+                if unit['type'] == "Base" and unit['player'] == player_id
             ]
         )
 
-    def _get_valid_attack_positions(self, state):
+    def _get_valid_attack_positions(self, state, player_id):
         return set(
             [
                 (unit['x'], unit['y']) for unit in state['pgs']['units']
-                if unit['type'] != "Resource" and unit['player'] != PLAYER
+                if unit['type'] != "Resource" and unit['player'] != player_id
             ]
         )
 
-    def get_valid_action_positions_for_state(self, state):
+    def get_valid_action_positions_for_state(self, state, player_id):
         """
         Returns a tuple containing the following:
         invalid_move_positions - a set of all the positions that cannot be moved into
@@ -174,8 +175,8 @@ class Server(object):
         return (
             self._get_invalid_move_positions(state),
             self._get_valid_harvest_positions(state),
-            self._get_valid_base_positions(state),
-            self._get_valid_attack_positions(state)
+            self._get_valid_base_positions(state, player_id),
+            self._get_valid_attack_positions(state, player_id)
         )
 
     def get_valid_actions_for_unit(self, unit, available_actions, valid_positions):

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -327,8 +327,11 @@ class Server(object):
         Gets the width and height of the environment
         """
 
-        self._max_x = state['pgs']['width']
-        self._max_y = state['pgs']['height']
+        # in case the state gets here uninitialized,
+        # due to network problems or a gameover
+        if state is not None and state != {}:
+            self._max_x = state['pgs']['width']
+            self._max_y = state['pgs']['height']
 
         return self._max_x, self._max_y
 

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -88,15 +88,16 @@ class Server(object):
 
         actions = self.get_action(state, gameover)
 
-        return self._filter_invalid_actions(actions, state)
+        if gameover:
+            return None
+        else:
+            return self._filter_invalid_actions(actions, state)
 
     def _wait_for_get_action(self):
         message_parts = self._wait_for_message()
         command = message_parts[0].split()
 
-        gameover = command[0] == 'gameOver'
-
-        if command[0] == 'getAction':
+        if command[0] in ['getAction', 'gameOver']:
             try:
                 state = json.loads(message_parts[1])
                 self._logger.debug('state: %s' % state)
@@ -106,7 +107,8 @@ class Server(object):
                 )
                 raise e
 
-            return self._process_state_and_get_action(state, gameover)
+            return self._process_state_and_get_action(state, command[0] == 'gameOver')
+
 
     def _get_budgets(self):
         _, self._time_budget, self._iteration_budget = self._wait_for_message()[0].split()

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -82,20 +82,19 @@ class Server(object):
         pass
 
     def _process_state_and_get_action(self, state, gameover):
+        # TODO it would be nice if get_action is called when gameover == True,
+        # so that the controller can find out if it has won or lost
         if gameover:
             return None
-        elif state == {}:
-            return []
-        else:
-            self.get_grid_from_state(state)
-            actions = self.get_action(state, gameover)
-            return self._filter_invalid_actions(actions, state)
+            
+        actions = self.get_action(state, gameover)
+        self.get_grid_from_state(state)
+        return self._filter_invalid_actions(actions, state)
 
     def _wait_for_get_action(self):
         message_parts = self._wait_for_message()
         command = message_parts[0].split()
 
-        state = {}
         gameover = command[0] == 'gameOver'
 
         if command[0] == 'getAction':
@@ -108,7 +107,7 @@ class Server(object):
                 )
                 raise e
 
-        return self._process_state_and_get_action(state, gameover)
+            return self._process_state_and_get_action(state, gameover)
 
     def _get_budgets(self):
         _, self._time_budget, self._iteration_budget = self._wait_for_message()[0].split()
@@ -326,12 +325,8 @@ class Server(object):
         """
         Gets the width and height of the environment
         """
-
-        # in case the state gets here uninitialized,
-        # due to network problems or a gameover
-        if state is not None and state != {}:
-            self._max_x = state['pgs']['width']
-            self._max_y = state['pgs']['height']
+        self._max_x = state['pgs']['width']
+        self._max_y = state['pgs']['height']
 
         return self._max_x, self._max_y
 

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -109,6 +109,8 @@ class Server(object):
 
             return self._process_state_and_get_action(state, command[0] == 'gameOver')
 
+        else:
+            return []
 
     def _get_budgets(self):
         _, self._time_budget, self._iteration_budget = self._wait_for_message()[0].split()

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -119,9 +119,18 @@ class Server(object):
         self._ack()
 
     def get_unit_type_table(self):
+        """Returns the unit type table, which describes the environment
+        
+        :return: [description]
+        """
         return self._unit_type_table
 
     def get_busy_units(self, state):
+        """Get a list of the units that are currently busy performing an action
+
+        :param state: [description]
+        :return: [description]
+        """
         return [unit['ID'] for unit in state['actions']]
 
     def _get_invalid_move_positions(self, state):

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -392,6 +392,7 @@ class Server(object):
         # Get the headers
         self._get_budgets()
         self._get_utt()
+        self._get_budgets()
 
         gameover = False
 

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -73,11 +73,11 @@ class Server(object):
 
     @abstractmethod
     def get_action(self, state, gameover):
-        """
-        To be implemented by a super class
-        :param state:
-        :param gameover:
-        :return:
+        """Send a list of actions to MicroRTS, given a state. Override this in
+           the super class.
+           
+           Be aware that, if `gameover = True`, the action provided will not be
+           processed by MicroRTS.
         """
         pass
 

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -55,7 +55,7 @@ class Server(object):
     def _wait_for_message(self):
         environment_message = self._connection.recv(8192).decode('utf-8')
         if environment_message[0] == u'\n':
-            return ('ACK')
+            return 'ACK'
         self._logger.debug('Message: %s' % environment_message)
         message_parts = environment_message.split('\n')
         self._logger.debug(message_parts[0])
@@ -382,6 +382,5 @@ class Server(object):
             else:
                 self._logger.debug('Game has ended')
                 gameover = True
-
 
         self._s.close()

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -137,14 +137,28 @@ class Server(object):
         return set([(unit['x'], unit['y']) for unit in state['pgs']['units']])
 
     def _get_valid_harvest_positions(self, state):
-        return set([(unit['x'], unit['y']) for unit in state['pgs']['units'] if unit['type'] == "Resource"])
+        return set(
+            [
+                (unit['x'], unit['y']) for unit in state['pgs']['units']
+                if unit['type'] == "Resource"
+            ]
+        )
 
     def _get_valid_base_positions(self, state):
-        return set([(unit['x'], unit['y']) for unit in state['pgs']['units'] if unit['type'] == "Base" and unit['player'] == PLAYER])
+        return set(
+            [
+                (unit['x'], unit['y']) for unit in state['pgs']['units']
+                if unit['type'] == "Base" and unit['player'] == PLAYER
+            ]
+        )
 
     def _get_valid_attack_positions(self, state):
-        return set([(unit['x'], unit['y']) for unit in state['pgs']['units'] if unit['type'] != "Resource" and unit['player'] != PLAYER])
-
+        return set(
+            [
+                (unit['x'], unit['y']) for unit in state['pgs']['units']
+                if unit['type'] != "Resource" and unit['player'] != PLAYER
+            ]
+        )
 
     def get_valid_action_positions_for_state(self, state):
         """

--- a/pyrts/server.py
+++ b/pyrts/server.py
@@ -83,13 +83,11 @@ class Server(object):
         pass
 
     def _process_state_and_get_action(self, state, gameover):
-        # TODO it would be nice if get_action is called when gameover == True,
-        # so that the controller can find out if it has won or lost
-        if gameover:
-            return None
-            
+        if not gameover:
+            self.get_grid_from_state(state)
+
         actions = self.get_action(state, gameover)
-        self.get_grid_from_state(state)
+
         return self._filter_invalid_actions(actions, state)
 
     def _wait_for_get_action(self):


### PR DESCRIPTION
This PR is an advanced version of #3. After I created #3, I realized I introduced new errors, so I decided to close that PR until I could create a better one.

A few corrections I saw necessary:

* I made the socket message size larger (from 4096 to 8192 bytes), as states with many entities were being truncated and sent in two messages, making it impossible to transform a single message as a JSON file;

* I changed the way a game over is detected. In the current method. any message different than `getAction` is interpreted as a game over. However, sometimes microRTS sends a `budget` message twice, making python-microRTS think the game is oiver before even sending the first action. microRTS has an explicit `gameOver` message, so I used that to determine when the game ends. I believe this change fixes #2 while the first point was an intermediate bug I found on the way.

* Lastly, I realized the python-microRTS controller never had access to the last state, when the game over happens. This may be interesting to users who wish to process a win or a loss in the Python side. Also, the `get_action` method had a `gameover` parameter, but it was always false. I made a few changes to make sure that a controller made by a user of python-microRTS can actually do something when the game is over. The action that is sent back from the controller to microRTS is just changed to `None` inside the Server class.